### PR TITLE
API Spec update, removes superfluous legalBasis, rename path

### DIFF
--- a/code/API_definitions/consent-info.yaml
+++ b/code/API_definitions/consent-info.yaml
@@ -72,27 +72,27 @@ tags:
   - name: Verify Status
     description: Create a request to verify the status of Consent or other Legal Basis
 paths:
-  /verify:
+  /get-status:
     post:
-      summary: Create a request to verify the status of Consent or other Legal Basis
+      summary: Get the processing status for some scopes and Purpose
       description: |
-        Create a request to verify the Consent or other Legal Basis of a specific User to the API Consumer for the requested scope(s) and Purpose. The API Consumer is identified by the `client_id` parameter deduced from the access token.
-      operationId: verifyConsentStatus
+        Get the processing status of a specific User for the requested scope(s) and Purpose. The API Consumer is identified by the `client_id` parameter deduced from the access token.
+      operationId: getProcessingStatus
       security:
         - openId:
-            - consent-info:verify
+            - consent-info:get-status
       tags:
-        - Verify Status
+        - Get Processing Status
       parameters:
         - $ref: '#/components/parameters/x-correlator'
       requestBody:
         required: true
         description:
-          Status verification request
+          Status request
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/VerifyStatusRequestBody"
+              $ref: "#/components/schemas/GetStatusRequestBody"
             examples:
               ONE_SCOPE_ONE_API:
                 summary: One scope
@@ -247,7 +247,7 @@ paths:
         "401":
           $ref: "#/components/responses/Generic401"
         "403":
-          $ref: "#/components/responses/verifyConsentStatus403"
+          $ref: "#/components/responses/getConsentStatus403"
         "404":
           $ref: "#/components/responses/Generic404"
         "422":
@@ -274,7 +274,7 @@ components:
       description: A public identifier addressing a telephone subscription. In mobile networks it corresponds to the MSISDN (Mobile Station International Subscriber Directory Number). In order to be globally unique it has to be formatted in international format, according to E.164 standard, prefixed with '+'.
       pattern: '^\+[1-9][0-9]{4,14}$'
       example: "+123456789"
-    VerifyStatusRequestBody:
+    GetStatusRequestBody:
       type: object
       description: |
         The request body for the status verification request. It contains the requested scope(s), the Purpose for which the API Consumer intends to process the User's Personal Data, a flag indicating whether the API Consumer requests a Consent capture URL and optionally the phone number of the User. The phone number is required when the API is invoked using a two-legged access token, but MUST NOT be provided when a three-legged access token is used, as the subject will be uniquely identified from the access token.
@@ -441,7 +441,7 @@ components:
                 status: 401
                 code: UNAUTHENTICATED
                 message: Request not authenticated due to missing, invalid, or expired credentials.
-    verifyConsentStatus403:
+    getConsentStatus403:
       description: Forbidden
       headers:
         x-correlator:

--- a/code/API_definitions/consent-info.yaml
+++ b/code/API_definitions/consent-info.yaml
@@ -26,7 +26,7 @@ info:
     Specifically, the API:
 
     * Provides the data processing validity status and reason: The API returns `statusValidForProcessing`, a boolean flag that is `true` if processing is permitted. If the flag is `false`, a `statusReason` field is also returned to explain why.
-    * Offers an URL where the User can provide the necessary Consent. This field is only present if requested by the API Consumer and if the legal basis for these Purpose and Scope is `dpv:Consent`, `statusInfo[*].statusValidForProcessing` is `false`, and `statusInfo[*].statusReason` is `PENDING`, `REQUESTED`, `REVOKED` or `EXPIRED`.
+    * Offers an URL where the User can provide the necessary Consent. This field is only present if requested by the API Consumer and if the legal basis for these Purpose and Scope is `dpv:Consent`, `statusInfo[*].statusValidForProcessing` is `false`, and `statusInfo[*].statusReason` is `PENDING`, `REQUESTED` or `EXPIRED`.
 
     Importantly, this API does NOT delegate Consent capture to the API Consumer but rather empowers the API Consumer to present the API Provider's Consent capture URL at the most opportune time and place. The actual Consent capture occurs within the API Provider's secure environment, ensuring the User's authentication with the API Provider.
 
@@ -319,7 +319,7 @@ components:
           type: string
           format: url
           description: |
-            URL where the User can provide the necessary Consent. This field is only present if requested by the API Consumer.
+            URL where the User can provide the necessary Consent. This field is only present if requested by the API Consumer and if the legal basis for these Purpose and Scope is `dpv:Consent`, `statusInfo[*].statusValidForProcessing` is `false`, and `statusInfo[*].statusReason` is `PENDING`, `REQUESTED` or `EXPIRED`.
           example: 'https://example.org/consent-capture-url'
     statusInfo:
       type: array

--- a/code/API_definitions/consent-info.yaml
+++ b/code/API_definitions/consent-info.yaml
@@ -193,7 +193,7 @@ paths:
                           - "number-verification:verify"
                         purpose: "dpv:FraudPreventionAndDetection"
                         statusValidForProcessing: false
-                        statusReason: REVOKED
+                        statusReason: OBJECTED
                 MULTIPLE_SCOPES_ONE_API:
                   summary: Multiple scopes for one API
                   description: |
@@ -239,7 +239,7 @@ paths:
                           - "sim-swap:retrieve-date"
                         purpose: "dpv:FraudPreventionAndDetection"
                         statusValidForProcessing: false
-                        statusReason: REVOKED
+                        statusReason: OBJECTED
         "400":
           $ref: "#/components/responses/Generic400"
         "401":

--- a/code/API_definitions/consent-info.yaml
+++ b/code/API_definitions/consent-info.yaml
@@ -5,7 +5,7 @@ info:
 
     The Consent Info API allows an API Consumer to verify the Consent status of a particular User for that API Consumer (identified by `client_id` from the access token) concerning requested scope(s) and a specific Purpose. It helps determine if Consent is legally required for these parameters. If Consent is necessary but not yet granted, or if it has expired, the API can provide a URL pointing to the API Provider's Consent capture channel. This enables the API Consumer to direct the User to grant or renew Consent in a secure and trusted environment.
 
-    While verifying User Consent is a primary use case, this API allows to check the validity of *any* Legal Basis (e.g., `dpv:Consent`, `dpv:LegitimateInterest`, `dpv:Contract`, etc) that authorizes data processing for a given Purpose.
+    While verifying User Consent is a primary use case, this API allows to check the validity of *any* Legal Basis agreed upon at API consumer onboardiing-time that authorizes data processing for a given scope and Purpose.
 
     # Introduction
 
@@ -149,7 +149,6 @@ paths:
                       - scopes:
                           - "number-verification:verify"
                         purpose: "dpv:FraudPreventionAndDetection"
-                        legalBasis: "dpv:LegitimateInterest"
                         statusValidForProcessing: true
                 CONSENT_REQUIRED:
                   summary: Consent is required
@@ -160,7 +159,6 @@ paths:
                       - scopes:
                           - "location-verification:verify"
                         purpose: "dpv:FraudPreventionAndDetection"
-                        legalBasis: "dpv:Consent"
                         statusValidForProcessing: false
                         statusReason: REQUESTED
                 CONSENT_REQUIRED_CAPTURE_URL:
@@ -172,7 +170,6 @@ paths:
                       - scopes:
                           - "location-verification:verify"
                         purpose: "dpv:FraudPreventionAndDetection"
-                        legalBasis: "dpv:Consent"
                         statusValidForProcessing: false
                         statusReason: EXPIRED
                         expirationDate: '2023-07-03T14:27:08.312+02:00'
@@ -186,7 +183,6 @@ paths:
                       - scopes:
                           - "location-verification:verify"
                         purpose: "dpv:FraudPreventionAndDetection"
-                        legalBasis: "dpv:Consent"
                         statusValidForProcessing: false
                         statusReason: REVOKED
                 LEGITIMATE_INTEREST_OPT_OUT:
@@ -198,7 +194,6 @@ paths:
                       - scopes:
                           - "number-verification:verify"
                         purpose: "dpv:FraudPreventionAndDetection"
-                        legalBasis: "dpv:LegitimateInterest"
                         statusValidForProcessing: false
                         statusReason: REVOKED
                 MULTIPLE_SCOPES_ONE_API:
@@ -214,7 +209,6 @@ paths:
                           - "quality-on-demand:sessions:delete"
                           - "quality-on-demand:sessions:retrieve-by-device"
                         purpose: "dpv:RequestedServiceProvision"
-                        legalBasis: "dpv:Contract"
                         statusValidForProcessing: true
                 MULTIPLE_SCOPES_MULTIPLE_APIS:
                   summary: Multiple scopes for multiple APIs
@@ -225,13 +219,11 @@ paths:
                       - scopes:
                           - "location-verification:verify"
                         purpose: "dpv:FraudPreventionAndDetection"
-                        legalBasis: "dpv:Consent"
                         statusValidForProcessing: false
                         statusReason: PENDING
                       - scopes:
                           - "device-roaming-status:read"
                         purpose: "dpv:FraudPreventionAndDetection"
-                        legalBasis: "dpv:Consent"
                         statusValidForProcessing: false
                         statusReason: PENDING
                     captureUrl: 'https://example.org/consent-capture-url'
@@ -244,12 +236,10 @@ paths:
                       - scopes:
                           - "sim-swap:check"
                         purpose: "dpv:FraudPreventionAndDetection"
-                        legalBasis: "dpv:LegitimateInterest"
                         statusValidForProcessing: true
                       - scopes:
                           - "sim-swap:retrieve-date"
                         purpose: "dpv:FraudPreventionAndDetection"
-                        legalBasis: "dpv:LegitimateInterest"
                         statusValidForProcessing: false
                         statusReason: REVOKED
         "400":
@@ -331,7 +321,7 @@ components:
           type: string
           format: url
           description: |
-            URL where the User can provide the necessary Consent. This field is only present if requested by the API Consumer and if `statusInfo[*].legalBasis` is `dpv:Consent`, `statusInfo[*].statusValidForProcessing` is `false`, and `statusInfo[*].statusReason` is `PENDING`, `REQUESTED` or `EXPIRED`.
+            URL where the User can provide the necessary Consent. This field is only present if requested by the API Consumer.
           example: 'https://example.org/consent-capture-url'
     statusInfo:
       type: array
@@ -346,30 +336,18 @@ components:
       required:
         - scopes
         - purpose
-        - legalBasis
         - statusValidForProcessing
       properties:
         scopes:
           $ref: "#/components/schemas/Scopes"
         purpose:
           $ref: "#/components/schemas/Purpose"
-        legalBasis:
-          type: string
-          description: |
-              The applicable Legal Basis for the requested scope(s) and Purpose. It uses terms from the W3C [Data Privacy Vocabulary](https://w3c.github.io/dpv/2.1/) (DPV).
-          enum:
-            - dpv:Consent
-            - dpv:LegitimateInterest
-            - dpv:Contract
-            - dpv:LegalObligation
-            - dpv:PublicInterest
-            - dpv:VitalInterest
         statusValidForProcessing:
           type: boolean
           description: |
-              Boolean flag that shows whether the specified Legal Basis is currently valid for processing data related to the indicated scope(s) and Purpose.
-              * `true` - The specified `legalBasis` is currently valid and permits the requested data processing. For example, necessary user Consent has been obtained; a legitimate interests assessment resulted in a positive outcome, with no overriding objections; or the processing is deemed necessary under an existing contract.
-              * `false` - The specified `legalBasis` is not valid for processing the requested scope(s) and Purpose. The reason for this is indicated in the `statusReason` field. This may be because the User has not yet provided Consent, has opted out of processing based on legitimate interest or because the Legal Basis is no longer applicable for other reasons.
+              Boolean flag that shows whether the specified `scope` and `Purpose` currently permit processing data.
+              * `true` - The specified `scope` and `Purpose` permit the requested data processing. For example, necessary user Consent has been obtained; a legitimate interests assessment resulted in a positive outcome, with no overriding objections; or the processing is deemed necessary under an existing contract.
+              * `false` - The specified `scope` and `Purpose` do not permit processing. The reason for this is indicated in the `statusReason` field. This may be because the User has not yet provided Consent, has opted out of processing based on legitimate interest.
         statusReason:
           type: string
           enum:
@@ -378,22 +356,22 @@ components:
             - REVOKED
             - EXPIRED
           description: |
-              This field must be present if `statusValidForProcessing` is `false`. It indicates the reason why the specified `legalBasis` is not valid for processing the requested scope(s) and Purpose. It provides API consumers with additional context on the current state of the Legal Basis, helping them to understand its applicability and the next steps they may need to take.
-              It is particularly useful for determining whether the API Consumer should prompt the User to take action, such as providing Consent or renewing an existing Consent.
+              This field must be present if `statusValidForProcessing` is `false`. It indicates the reason why processing is for the specified `scope` and `purpose` is invalid.
+              `statusReason`is useful for determining whether the API Consumer should prompt the user to take action, such as providing Consent or renewing an existing Consent.
               Possible values are:
               - `PENDING`: The specified `legalBasis` is not yet established or fully validated for the requested data processing.
                            For example, the user has not yet provided Consent under `dpv:Consent` Legal Basis.
-              - `REQUESTED`: Where applicable, the specified `legalBasis` has been requested but not yet granted or confirmed.
+              - `REQUESTED`: Where applicable, the permission for processing for the specified scope and Purpose has been requested but not yet granted or confirmed.
                            This is common for `dpv:Consent`, where the API Consumer has initiated a request for Consent capture, but the User has not yet completed the process. For example, this occurs when a notice prompting the User to Provide consent has been displayed, but they have not yet made a decision.
-              - `REVOKED`: Where applicable (primarily for `dpv:Consent` and `dpv:LegitimateInterest`), the user has actively withdrawn their permission, or the previously valid `legalBasis` is no longer considered so due to user action.
+              - `REVOKED`: The user has actively withdrawn their permission.
                            This includes revocation of Consent or a successful objection (opt-out) to processing based on legitimate interest.
-              - `EXPIRED`: Where applicable, the validity of the `legalBasis` for data processing has ceased due to the passage of time or a pre-defined condition.
+              - `EXPIRED`: Where applicable, the validity for data processing has ceased due to the passage of time or a pre-defined condition.
                            This is common for time-limited Consents or could apply to other Legal Basis if their applicability was time-bound.
         expirationDate:
           type: string
           format: date-time
           description: |
-             The date and time at which the validity of this `legalBasis` is set to expire or has expired.
+             The date and time at which the validity for processing is set to expire or has expired.
              It applies mainly to time-limited Legal Basis, such as `dpv:Consent`, or others where a specific duration of validity is defined. This field is only applicable if `statusValidForProcessing` is `true` (indicating a future expiration) or if `statusValidForProcessing` is `false` and `statusReason` is `EXPIRED` (indicating the past expiration date). It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6) and must have time zone. Recommended format is yyyy-MM-dd'T'HH:mm:ss.SSSZ (i.e. which allows 2023-07-03T14:27:08.312+02:00 or 2023-07-03T12:27:08.312Z).
           example: '2023-07-03T14:27:08.312+02:00'
     ErrorInfo:
@@ -577,3 +555,4 @@ components:
     openId:
       type: openIdConnect
       openIdConnectUrl: https://example.org/.well-known/openid-configuration
+

--- a/code/API_definitions/consent-info.yaml
+++ b/code/API_definitions/consent-info.yaml
@@ -26,7 +26,7 @@ info:
     Specifically, the API:
 
     * Provides the data processing validity status and reason: The API returns `statusValidForProcessing`, a boolean flag that is `true` if processing is permitted. If the flag is `false`, a `statusReason` field is also returned to explain why.
-    * Offers an URL where the user can manage their consent. If the API Consumer sets `requestCaptureUrl` to `true`, and if a user needs to provide or renew their Consent, the API supplies the API Provider's Consent capture URL.
+    * Offers an URL where the User can provide the necessary Consent. This field is only present if requested by the API Consumer and if the legal basis for these Purpose and Scope is `dpv:Consent`, `statusInfo[*].statusValidForProcessing` is `false`, and `statusInfo[*].statusReason` is `PENDING`, `REQUESTED`, `REVOKED` or `EXPIRED`.
 
     Importantly, this API does NOT delegate Consent capture to the API Consumer but rather empowers the API Consumer to present the API Provider's Consent capture URL at the most opportune time and place. The actual Consent capture occurs within the API Provider's secure environment, ensuring the User's authentication with the API Provider.
 

--- a/code/API_definitions/consent-info.yaml
+++ b/code/API_definitions/consent-info.yaml
@@ -9,26 +9,24 @@ info:
 
     # Introduction
 
-    The primary function of this API is to enable API Consumers to ascertain the authorization status for processing personal data before using other APIs. By providing a standardized way to check the validity of a legal basis, this API facilitates compliance with privacy regulations and promotes transparency with users. Key inputs include the specific scope(s) of access being requested, the Purpose for data processing, and an identifier for the User (either explicitly provided or derived from a three-legged access token). The API responds with the validity status of the applicable Legal Basis, and, if the Legal Basis is `dpv:Consent`, can provide a URL for the API Consumer to manage it.
+    The primary function of this API is to enable API Consumers to ascertain the authorization status for processing personal data before using other APIs. By providing a standardized way to check whether e.g the user granted their consent or opted-out, this API facilitates compliance with privacy regulations and promotes transparency with users. Key inputs include the specific scope(s) of access being requested, the Purpose for data processing, and an identifier for the User (either explicitly provided or derived from a three-legged access token). The API responds with whether processing personal information is valid and with an URL where the user e.g. can manage their consent.
 
     # Relevant terms and definitions
 
     * **Consent**: An explicit opt-in action that the User takes to allow processing of Personal Data. Consent grants the API Consumer access to a set of scopes related to the User for a specific Purpose.
     * **Purpose**: The reason for which Personal Data will be processed by an API Consumer. CAMARA defines a standard set of Purposes which can be used by API Consumers to specify the reason for their intended Personal Data processing.
     * **Scope**: A string representing the specific access rights or actions an API Consumer requests from the User for their data (e.g., "location-verification:verify"). A request can contain multiple scopes.
-    * **Legal Basis**: The justification under data protection law for processing Personal Data. It identifies the lawful ground on which the API Consumer relies (e.g., Consent, Contract, Legitimate Interest).
-
-    This API adopts the [W3C Data Privacy Vocabulary](https://w3c.github.io/dpv/2.0/dpv/) (DPV) to represent both Purpose and Legal Basis. For example, Legal Basis include values such as `dpv:Consent` or `dpv:LegitimateInterest`, while Purposes include `dpv:FraudPreventionAndDetection` or `dpv:RequestedServiceProvision`.
+    
+    This API adopts the [W3C Data Privacy Vocabulary](https://w3c.github.io/dpv/2.0/dpv/) (DPV) to represent Purpose, e.g. `dpv:FraudPreventionAndDetection` or `dpv:RequestedServiceProvision`.
 
     # API Functionality
 
-    This API enables an API Consumer to determine whether user Consent (or another valid Legal Basis) is in place for the requested actions, based on the provided scope(s) and Purpose, and for the specific API Consumer making the request. NOTE: The response may contain multiple array items, for instance, if the requested scopes pertain to different underlying services or require distinct legal assessments (e.g., some scopes rely on `dpv:Consent` while others rely on `dpv:LegitimateInterest`).
+    This API enables an API Consumer to determine whether permission of processing personal data is in place for the requested actions, based on the provided scope(s) and Purpose, and for the specific API Consumer making the request. NOTE: The response may contain multiple array items, for instance, if the requested scopes pertain to different underlying services.
 
     Specifically, the API:
 
-    * Indicates the applicable Legal Basis: Indicates which legal basis (e.g., `dpv:Consent`, `dpv:LegitimateInterest`) is required for the requested scopes, Purpose, and API Consumer according to relevant legal frameworks.
     * Provides the data processing validity status and reason: The API returns `statusValidForProcessing`, a boolean flag that is `true` if processing is permitted. If the flag is `false`, a `statusReason` field is also returned to explain why.
-    * Offers a Consent Capture URL: This functionality is specific to the `dpv:Consent` legal basis. If the API Consumer sets `requestCaptureUrl` to `true`, and if a user needs to provide or renew their Consent, the API supplies the API Provider's Consent capture URL.
+    * Offers an URL where the user can manage their consent. If the API Consumer sets `requestCaptureUrl` to `true`, and if a user needs to provide or renew their Consent, the API supplies the API Provider's Consent capture URL.
 
     Importantly, this API does NOT delegate Consent capture to the API Consumer but rather empowers the API Consumer to present the API Provider's Consent capture URL at the most opportune time and place. The actual Consent capture occurs within the API Provider's secure environment, ensuring the User's authentication with the API Provider.
 
@@ -355,24 +353,26 @@ components:
             - REQUESTED
             - REVOKED
             - EXPIRED
+            - OBJECTED
           description: |
               This field must be present if `statusValidForProcessing` is `false`. It indicates the reason why processing is for the specified `scope` and `purpose` is invalid.
               `statusReason`is useful for determining whether the API Consumer should prompt the user to take action, such as providing Consent or renewing an existing Consent.
               Possible values are:
               - `PENDING`: The specified `legalBasis` is not yet established or fully validated for the requested data processing.
-                           For example, the user has not yet provided Consent under `dpv:Consent` Legal Basis.
+                           For example, the user has not yet provided Consent.
               - `REQUESTED`: Where applicable, the permission for processing for the specified scope and Purpose has been requested but not yet granted or confirmed.
-                           This is common for `dpv:Consent`, where the API Consumer has initiated a request for Consent capture, but the User has not yet completed the process. For example, this occurs when a notice prompting the User to Provide consent has been displayed, but they have not yet made a decision.
+                           For example, this occurs when a notice prompting the User to provide consent has been displayed, but they have not yet made a decision.
               - `REVOKED`: The user has actively withdrawn their permission.
                            This includes revocation of Consent or a successful objection (opt-out) to processing based on legitimate interest.
               - `EXPIRED`: Where applicable, the validity for data processing has ceased due to the passage of time or a pre-defined condition.
                            This is common for time-limited Consents or could apply to other Legal Basis if their applicability was time-bound.
+              - `OBJECTED`: The user has opted-out. The API Provider is not providing personal data to the API consumer after the objection.
         expirationDate:
           type: string
           format: date-time
           description: |
              The date and time at which the validity for processing is set to expire or has expired.
-             It applies mainly to time-limited Legal Basis, such as `dpv:Consent`, or others where a specific duration of validity is defined. This field is only applicable if `statusValidForProcessing` is `true` (indicating a future expiration) or if `statusValidForProcessing` is `false` and `statusReason` is `EXPIRED` (indicating the past expiration date). It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6) and must have time zone. Recommended format is yyyy-MM-dd'T'HH:mm:ss.SSSZ (i.e. which allows 2023-07-03T14:27:08.312+02:00 or 2023-07-03T12:27:08.312Z).
+             It applies mainly to time-limited grants that allows processing of personal data, or others where a specific duration of validity is defined. This field is only applicable if `statusValidForProcessing` is `true` (indicating a future expiration) or if `statusValidForProcessing` is `false` and `statusReason` is `EXPIRED` (indicating the past expiration date). It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6) and must have time zone. Recommended format is yyyy-MM-dd'T'HH:mm:ss.SSSZ (i.e. which allows 2023-07-03T14:27:08.312+02:00 or 2023-07-03T12:27:08.312Z).
           example: '2023-07-03T14:27:08.312+02:00'
     ErrorInfo:
       type: object


### PR DESCRIPTION
#### What type of PR is this?

documentation

#### What this PR does / why we need it:

- Legal basis is know to the API Consumer and does not provide vital information.
- Rename the name of the path from "verify" to "get-status" because this API does not verify/validate the API Consumer has about the current privacy status but gets the status.




#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #

#### Special notes for reviewers:



#### Changelog input

```
 release-note

```

#### Additional documentation 

This section can be blank.



```
docs

```
